### PR TITLE
Push 4 bug fixes and a number of upgrades

### DIFF
--- a/cwaitfor.c
+++ b/cwaitfor.c
@@ -4,17 +4,19 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <stdint.h>
+#include <time.h>
 
-void c_run_command(int *retval,char *cmd) {
+void c_run_command(int64_t *retval,char *cmd) {
   *retval=system(cmd);
 }
 
-void cwaitfor(int *status, int *minage, int *minsize, int *maxwait,
-              int *sleeptime, char *filename) {
+void cwaitfor(int64_t *status, int64_t *minage, int64_t *minsize, int64_t *maxwait,
+              int64_t *sleeptime, char *filename) {
   struct stat s;
   time_t now=time(NULL);
-  int maxwaitv=*maxwait;
-  int size,age;
+  int64_t maxwaitv=*maxwait;
+  int64_t size,age;
   fprintf(stderr,"%s: cwaitfor with minage=%d minsize=%d maxwait=%d=%d sleeptime=%d\n",
           filename,*minage,*minsize,*maxwait,maxwaitv,*sleeptime);
   while(maxwaitv<0 || time(NULL)-now<maxwaitv) {
@@ -40,28 +42,28 @@ void cwaitfor(int *status, int *minage, int *minsize, int *maxwait,
   return;
 }
 
-void c_run_command_(int*r,char*c) { c_run_command(r,c); }
-void c_run_command__(int*r,char*c) { c_run_command(r,c); }
-void C_RUN_COMMAND(int*r,char*c) { c_run_command(r,c); }
-void C_RUN_COMMAND_(int*r,char*c) { c_run_command(r,c); }
-void C_RUN_COMMAND__(int*r,char*c) { c_run_command(r,c); }
+void c_run_command_(int64_t*r,char*c) { c_run_command(r,c); }
+void c_run_command__(int64_t*r,char*c) { c_run_command(r,c); }
+void C_RUN_COMMAND(int64_t*r,char*c) { c_run_command(r,c); }
+void C_RUN_COMMAND_(int64_t*r,char*c) { c_run_command(r,c); }
+void C_RUN_COMMAND__(int64_t*r,char*c) { c_run_command(r,c); }
 
-void cwaitfor_(int*a,int*b,int*c,int*d,int*e,char*f) {
+void cwaitfor_(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void cwaitfor__(int*a,int*b,int*c,int*d,int*e,char*f) {
+void cwaitfor__(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void CWAITFOR(int*a,int*b,int*c,int*d,int*e,char*f) {
+void CWAITFOR(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void CWAITFOR_(int*a,int*b,int*c,int*d,int*e,char*f) {
+void CWAITFOR_(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }
 
-void CWAITFOR__(int*a,int*b,int*c,int*d,int*e,char*f) {
+void CWAITFOR__(int64_t*a,int64_t*b,int64_t*c,int64_t*d,int64_t*e,char*f) {
   cwaitfor(a,b,c,d,e,f);
 }

--- a/gettrk_main.f
+++ b/gettrk_main.f
@@ -2637,8 +2637,8 @@ c             flag will have a value of 'U', for "undetermined".
                         print *,'       xval(9) = ',xval(9) 
                         print *,'       EXITING....' 
                         print *,' ' 
-                        stop 95
                       endif
+                      stop 95
                     endif
 
                     ! In the event that we have the case where both the
@@ -2803,7 +2803,7 @@ c             flag will have a value of 'U', for "undetermined".
                         if (closed_mslp_ctr_flag2(ist,ifh) == 'n' .and.
      &                      closed_mslp_ctr_flag2(ist,ifh-1) == 'n')
      &                  then
-                          if ( verb .ge. 3 ) then
+                          if ( verb .ge. 0 ) then
                             print *,' '
                             print *,'!!! Storm ID = '
      &                             ,storm(ist)%tcv_storm_id
@@ -2821,11 +2821,11 @@ c             flag will have a value of 'U', for "undetermined".
                             print *,'!!! and  ifh-1 = ',ifh-1
                             print *,'!!! TRACKING WILL STOP FOR'
                             print *,'!!! THIS STORM'
-                            fixlon (ist,ifh) = -999.0
-                            fixlat (ist,ifh) = -999.0
-                            stormswitch(ist) = 2
-                            cycle stormloop
                           endif
+                          fixlon (ist,ifh) = -999.0
+                          fixlat (ist,ifh) = -999.0
+                          stormswitch(ist) = 2
+                          cycle stormloop
                         endif
                       endif
 
@@ -3268,7 +3268,7 @@ c                  print *,'At pt isi, type= ',trkrinfo%type == 'tracker'
      &                          .and.
      &                          quad_wind_circ_flag(ist,ifh-1) == 'n')
      &                      then
-                              if ( verb .ge. 3 ) then
+                              if ( verb .ge. 0 ) then
                                 print *,' '
                                 print *,'!!! Storm ID = '
      &                                 ,storm(ist)%tcv_storm_id
@@ -3288,11 +3288,11 @@ c                  print *,'At pt isi, type= ',trkrinfo%type == 'tracker'
      &                                 ,ifh-1
                                 print *,'!!! TRACKING WILL STOP FOR'
                                 print *,'!!! THIS STORM'
-                                fixlon (ist,ifh) = -999.0
-                                fixlat (ist,ifh) = -999.0
-                                stormswitch(ist) = 2
-                                cycle stormloop
                               endif
+                              fixlon (ist,ifh) = -999.0
+                              fixlat (ist,ifh) = -999.0
+                              stormswitch(ist) = 2
+                              cycle stormloop
                             endif
                           endif
                         endif
@@ -3483,7 +3483,7 @@ c                  endif
 
                   if (xknots > xmaxspeed) then
 
-                    if ( verb .ge. 3 ) then
+                    if ( verb .ge. 0 ) then
                       print *,' '
                       print *,'!!! In routine  tracker, calculated spd'
                       print *,'!!! of the storm from the last position'
@@ -3540,7 +3540,7 @@ c                  endif
 c              if (igmwret /= 0 .and. gridmove_status == 'stopped') then
               if (igmwret /= 0) then
                 
-                if ( verb .ge. 3 ) then
+                if ( verb .ge. 0 ) then
                   print *,' '
                   print *,'!!! Return code from get_max_wind is /= 0. '
                   print *,'!!! rcc= igmwret= ',igmwret
@@ -3660,7 +3660,7 @@ c     &           c          ,first_time_thru_getradii,igrct,igrret)
      &                      ,igrret)
 
                   if (igrret /= 0) then
-                    if (verb >= 3) then
+                    if (verb >= 0) then
                       print *,' '
                       print *,'!!! ERROR: Return code from getradii_2= '
      &                       ,igrret
@@ -3669,8 +3669,8 @@ c     &           c          ,first_time_thru_getradii,igrct,igrret)
                       print *,'!!! all radii values will be set to '
                       print *,'!!! missing.'
                       print *,' '
-                      exit getrad_iter_loop
                     endif
+                    exit getrad_iter_loop
                   endif
 
                   ix_radii_beg = ix_radii_end
@@ -7865,7 +7865,7 @@ c     Now compute the fractional wind coverage for all
 c     the different quadrants, bins and thresholds...
 c     -------------------------------------------------
 
-      if ( verb .ge. 3 ) then
+      if ( verb .ge. 0 ) then
         write (6,109) '                                 '
      &       ,'                                     '
      &       ,'                '
@@ -9608,9 +9608,10 @@ c          print *,'+++ NOTE: In bilin_int_uneven, pts with invalid '
 c          print *,'          data were accessed.  We are likely at'
 c          print *,'          the edge of a regional grid.'
 c          print *,'          iw= ',iw,' ie= ',ie,' jn= ',jn,' js= ',js
-          ibiret = 85          
-          return
+          continue
         endif
+        ibiret = 85
+        return
       endif 
 
       select case (level)
@@ -10210,7 +10211,7 @@ c
         ! Pressure units are in Pa...
         mslp_outp_adj = 100.0
       else
-        if (verb .ge. 3) then
+        if (verb .ge. 0) then
           print *,' '
           print *,'ERROR: Something wrong in subroutine'
           print *,'       output_atcfunix.  The mslp value'
@@ -10218,8 +10219,8 @@ c
           print *,'       xminmslp = ',xminmslp
           print *,'       EXITING....'
           print *,' '
-          stop 95
         endif
+        stop 95
       endif
 
       conv_ms_knots = 1.9427
@@ -10627,7 +10628,7 @@ c
         ! Pressure units are in Pa...
         mslp_outp_adj = 100.0
       else
-        if (verb .ge. 3) then
+        if (verb .ge. 0) then
           print *,' '
           print *,'ERROR: Something wrong in subroutine'
           print *,'       output_aext.  The mslp value'
@@ -10635,8 +10636,8 @@ c
           print *,'       xminmslp = ',xminmslp
           print *,'       EXITING....'
           print *,' '
-          stop 95
         endif
+        stop 95
       endif
 
       conv_ms_knots = 1.9427
@@ -11519,7 +11520,7 @@ c     need to mod it to get it in a 0-360 framework.
         ! Pressure units are in Pa...
         mslp_outp_adj = 100.0
       else
-        if (verb .ge. 3) then
+        if (verb .ge. 0) then
           print *,' '
           print *,'ERROR: Something wrong in subroutine'
           print *,'       output_hfip.  The mslp value'
@@ -11527,8 +11528,8 @@ c     need to mod it to get it in a 0-360 framework.
           print *,'       xminmslp = ',xminmslp
           print *,'       EXITING....'
           print *,' '
-          stop 95
         endif
+        stop 95
       endif
 
       conv_ms_knots = 1.9427
@@ -12704,7 +12705,7 @@ c
         ! Pressure units are in Pa...
         mslp_outp_adj = 100.0
       else
-        if (verb .ge. 3) then
+        if (verb .ge. 0) then
           print *,' '
           print *,'ERROR: Something wrong in subroutine'
           print *,'       output_atcf_gen.  The mslp value'
@@ -12712,8 +12713,8 @@ c
           print *,'       xminmslp = ',xminmslp
           print *,'       EXITING....'
           print *,' '
-          stop 95
         endif
+        stop 95
       endif
 
 c     First convert all of the lat/lon values from reals into integers.
@@ -13167,7 +13168,7 @@ c
         ! Pressure units are in Pa...
         mslp_outp_adj = 100.0
       else
-        if (verb .ge. 3) then
+        if (verb .ge. 0) then
           print *,' '
           print *,'ERROR: Something wrong in subroutine'
           print *,'       output_atcf_gen.  The mslp value'
@@ -13175,8 +13176,8 @@ c
           print *,'       xminmslp = ',xminmslp
           print *,'       EXITING....'
           print *,' '
-          stop 95
         endif
+        stop 95
       endif
 
 c     First convert all of the lat/lon values from reals into integers.
@@ -17020,12 +17021,12 @@ c                  if (pct_holland_good_2 >= 0.75) then
      &                       ,f9.2)
                       print *,' '
 
-                      vradius(1,iquad) = 0
-                      vradius(2,iquad) = 0
-                      vradius(3,iquad) = 0
-                      exit threshloop
-
                     endif
+
+                    vradius(1,iquad) = 0
+                    vradius(2,iquad) = 0
+                    vradius(3,iquad) = 0
+                    exit threshloop
 
                   endif
                 endif
@@ -17239,10 +17240,10 @@ c     that we are sure radmaxwind is within those points.
             print *,'modified jbeg = jbeg= ',jbeg
             print *,'jlatfix = ',jlatfix
             print *,'Value of vmax will be set to 0 for this time.'
-            vmax = 0.0
-            igmwret = 99
-            return
           endif
+          vmax = 0.0
+          igmwret = 99
+          return
         else
           if (verb .ge. 3) then
             print *,' '
@@ -17277,10 +17278,10 @@ c     that we are sure radmaxwind is within those points.
             print *,'modified jend = jend= ',jend
             print *,'jlatfix = ',jlatfix
             print *,'Value of vmax will be set to 0 for this time.'
-            vmax = 0.0
-            igmwret = 99
-            return
           endif
+          vmax = 0.0
+          igmwret = 99
+          return
         else
           if (verb .ge. 3) then
             print *,' '
@@ -25055,8 +25056,8 @@ c     *--------------------------------------------------------------*
                 print *,'!!! phase-checking with a simple warm-core'
                 print *,'!!! check, then in the namelist set phaseflag'
                 print *,'!!! to y and set phasescheme to vtt.'
-                phaseflag = 'n'
               endif
+              phaseflag = 'n'
               exit netcdf_cps_parm_read_loop
             else
               if (verb .ge. 3) then
@@ -26625,9 +26626,9 @@ c------
             print *,'!!! is named tcvit_rsmc_storms.txt'
             print *,'!!! STOPPING....'
             print *,'!!! '
-            iret=99
-            return
           endif
+          iret=99
+          return
 
         else
 
@@ -26764,9 +26765,9 @@ c            write (storm(i)%tcv_storm_name,'(i4.4)') i
             print *,'!!! named tcvit_rsmc_storms.txt'
             print *,'!!! STOPPING...'
             print *,'!!! '
-            iret=99
-            return
           endif
+          iret=99
+          return
         endif
 
         allocate (stormswitch(maxstorm),stat=isa)
@@ -27668,8 +27669,6 @@ c17Jul2014      if (glonmax < 0.0) glonmax = 360. - abs(glonmax)
             print *,'         original glonmin= ',glonmin
             print *,'         original glonmax= ',glonmax
             print *,'       '
-            glonmax = glonmax + 360. 
-            gm_wrap_flag = 'maxplus360'
             print *,'       '
             print *,'       GRID MIN & MAX LON '
             print *,'         (MODIFIED FOR GM WRAPPING):'
@@ -27677,6 +27676,8 @@ c17Jul2014      if (glonmax < 0.0) glonmax = 360. - abs(glonmax)
             print *,'         glonmax (modified)=         ',glonmax
             print *,'       '
           endif
+          glonmax = glonmax + 360.
+          gm_wrap_flag = 'maxplus360'
         endif
       elseif (glonmin < 0.0 .and. glonmax >= 0.0) then
         ! An example of this is the MPAS data, which starts and ends
@@ -30808,15 +30809,18 @@ c     ifamret  return code from this subroutine
 
       type (trackstuff) trkrinfo
       type (cint_stuff) contour_info
+      integer    date_time(8)
       integer    stormct,i,j,ibeg,iend,jbeg,jend,ix,jx,ixp1,ixm1
       integer    ip,jp,maxstorm,jxp1,jxm1,ifamret,isret,iaret,iclmret
       integer    isoiret,icccret,igicwret,imax,jmax,ifh,totpts
       integer    eligible_pts,isia,ipa,candidate_ct,ist,ict,iia,ija
       integer    icmrgret,cand_not_valid_ct,cand_masked_out_ct
-      integer    cand_cc_good_ct,cand_cc_bad_ct
+      integer    cand_cc_good_ct,cand_cc_bad_ct,iccwcret
       integer(kind=8)    ssct1,yyct1,yyct2,zzct1,zzct2,zzct3
+      character (len=10) big_ben(3)
       character ccflag*1,get_last_isobar_flag*1,point_is_over_water*1
-      character pass_checks*1
+      character pass_checks*1,low_level_wind_circ_flag*1
+      character try_low_level_circ*1
       character(*) cmaxmin
       character(*) gm_wrap_flag
       logical(1) still_finding_valid_maxmins,rough_gradient_check_okay
@@ -31032,8 +31036,79 @@ c            print *,'xxtim b4 call_mslp_chk, ip= ',ip,' jp= ',jp
               prstemp(candidate_ct)  = fxy(ip,jp)
               ipos(candidate_ct)     = ip
               jpos(candidate_ct)     = jp
+
+              if (verb >= 3) then
+                print *,' '
+                print *,'+++ mslp radial grad SUCCESS, candidate_ct= '
+     &                 ,candidate_ct,' ip= ',ip,' jp= ',jp
+              endif
             else
-              cycle iloop_g
+
+              ! If the  check_mslp_radial_gradient has failed, we give
+              ! a 2nd chance (it's possible that the MSLP field was too
+              ! noisy) by checking for a closed low-level wind 
+              ! circulation, approximating what is done in NHC
+              ! operations.
+
+              try_low_level_circ = 'n'
+
+              if (try_low_level_circ == 'y') then
+
+                if (verb >= 3) then
+                  print *,' '
+                  print *,'mslp radial grad FAILED, checking LL wind...'
+                endif
+
+                call date_and_time (big_ben(1),big_ben(2),big_ben(3)
+     &                             ,date_time)
+                write (6,31) date_time(5),date_time(6),date_time(7)
+ 31             format (1x,'TIMING: b4 check_for_closed_wind_circ at '
+     &                    ,i2.2,':',i2.2,':',i2.2)
+
+                low_level_wind_circ_flag = 'n'
+                call check_for_closed_wind_circulation (imax,jmax,ip,jp
+     &                 ,dx,dy,valid_pt,trkrinfo,ifh
+     &                 ,low_level_wind_circ_flag,gm_wrap_flag,iccwcret)
+
+                call date_and_time (big_ben(1),big_ben(2),big_ben(3)
+     &                             ,date_time)
+                write (6,33) date_time(5),date_time(6),date_time(7)
+ 33             format (1x,'TIMING: after check_for_closed_wind_circ at'
+     &                  ,' ',i2.2,':',i2.2,':',i2.2)
+
+                if (iccwcret == 0) then
+                  if (low_level_wind_circ_flag == 'y') then
+                    candidate_ct           = candidate_ct + 1
+                    prstemp(candidate_ct)  = fxy(ip,jp)
+                    ipos(candidate_ct)     = ip
+                    jpos(candidate_ct)     = jp 
+                    if (verb >= 3) then
+                      print *,' '
+                      print *,' +++ Successful check of LL wind circ, '
+     &                       ,' ip= ',ip,' jp= ',jp
+                      print *,' '
+                    endif
+                  else
+                    if (verb >= 3) then
+                      print *,' '
+                      print *,' !!! Failed check 1 of LL wind circ, '
+     &                       ,' ip= ',ip,' jp= ',jp
+                      print *,' '
+                    endif
+                    cycle iloop_g
+                  endif
+                else
+                  if (verb >= 3) then
+                    print *,' '
+                    print *,' !!! Failed check 2 of LL wind circ, '
+     &                       ,' ip= ',ip,' jp= ',jp
+                    print *,' '
+                  endif
+                  cycle iloop_g
+                endif
+
+              endif
+ 
             endif
 
           endif
@@ -31081,7 +31156,7 @@ c     -----------------------------------------------------------------
  82     format (1x,'ist= ',i6,'  sortindex(ist)= ',i6
      &         ,' prstemp= ',f8.3,' i= ',i5,' j= ',i5,'  Lon= '
      &         ,f7.2,'W   (',f7.2,'E),  Lat= ',f7.2)
-        endif
+      endif
 
 c     Now process through the candidates.  We pass the (i,j) coordinates
 c     for each candidate point to a routine to check for a closed
@@ -31559,6 +31634,206 @@ c     &          ,' iazim_good_ct= ',i3,' num_azim= ',i3)
         icmrgret = 95
       endif
 c      
+      return
+      end
+c
+c---------------------------------------------------------------------
+c
+c---------------------------------------------------------------------
+      subroutine check_for_closed_wind_circulation (imax,jmax,ip,jp
+     &                ,dx,dy,valid_pt,trkrinfo,ifh
+     &                ,low_level_wind_circ_flag,gm_wrap_flag,iccwcret)
+c
+c     ABSTRACT: This subroutine checks for a low-level (10-m) 
+c     cyclonic circulation, in a manner that is meant to emulate how
+c     NHC assesses a disturbance in order to determine whether or not
+c     TC formation has occurred.  We will do a check at three different
+c     radii (initially 75, 125 and 175 km), and if the check passes at
+c     any one of these, then the low-level wind circulation is 
+c     satisfied, the flag is set to y, and the subroutine returns to
+c     the calling routine.  At each candidate radius, we do a check of
+c     the Vt at 16 equally-spaced azimuths.  There are 4 points in each
+c     quadrant.  We average those 4 points to get a mean Vt for that
+c     azimuth.  Once we have a mean Vt for all 16 azimuths, go through 
+c     the azimuths, one at a time, in a clockwise fashion, and check to see
+c     if their mean cyclonic Vt passes a threshold.  As long as 2 in a
+c     row do not fail, the test passes (i.e., every other one can pass
+c     and that is okay).
+c     
+c     INPUT:
+c
+c     imax      max i dimension of model grid
+c     jmax      max j dimension of model grid
+c     ip        i index for candidate location of local max or min
+c     jp        j index for candidate location of local max or min
+c     dx        grid spacing in i-direction of model grid
+c     dy        grid spacing in j-direction of model grid
+c     valid_pt  logical bitmap for valid data at a grid point
+c     trkrinfo  derived type detailing user-specified grid info
+c     ifh       integer index for the current lead time being processed
+c     gm_wrap_flag character flag set in getgridinfo that determines
+c               what GM-wrapping setting to use for this grid.
+c
+c     OUTPUT:
+c
+c     low_level_wind_circ_flag  character flag that will inform the 
+c               calling routine as to whether or not a low-level 
+c               closed circulation was found.
+c     iccwcret  return code from this subroutine
+
+      USE grid_bounds; USE tracked_parms; USE trig_vals; USE trkrparms
+      USE verbose_output
+
+      implicit none
+
+      type (trackstuff) trkrinfo
+
+      integer, parameter :: numdist=3,numazim=16,numquad=4
+      integer, intent(in) :: ip,jp
+      integer   vt_exceed_17kts_ct(numquad,numdist)
+      integer   vtct(numquad,numdist)
+      integer   date_time(8)
+      integer   imax,jmax,idist,azimuth_ct,ibiret1,ibiret2,bimct,iq,nq
+      integer   final_quad_ct,iccwcret,iazim,igvtret,ifh
+      real      xcandlon,ycandlat
+      real      rdist(numdist)
+      real      vtsum(numquad,numdist)
+      real      dx,dy,bear,targlat,targlon,xintrp_u,xintrp_v,vr,vt
+      real      hemisphere,vtavg
+      character :: low_level_wind_circ_flag*1
+      character :: quad_pass_flag(numquad)*1
+      character (*)  gm_wrap_flag
+      logical(1) valid_pt(imax,jmax)
+c
+      data rdist/75.,125.,175./  ! Distances in km
+c
+      vt_exceed_17kts_ct = 0
+      quad_pass_flag     = 'n'
+      vtsum              = 0.0
+      vtct               = 0
+      iccwcret           = 0
+      igvtret            = 0
+
+      bimct = 0
+
+      xcandlon = glonmin + ((ip - 1) * dx)
+      ycandlat = glatmax - ((jp - 1) * dy)
+
+      if (ycandlat >= 0.0) then
+        hemisphere = 1.0
+      else
+        hemisphere = -1.0
+      endif
+
+      radiusloop: do idist = 1,numdist
+
+        azimuth_ct = 0
+
+        azimloop: do iazim = 1,numazim
+
+          bear = ((iazim-1) * 22.5) + 11.25
+
+          call distbear (ycandlat,xcandlon,rdist(idist)
+     &                  ,bear,targlat,targlon,gm_wrap_flag)
+
+          if (gm_wrap_flag == 'maxplus360') then
+            if ((xcandlon > 330. .and. xcandlon <= 360.)
+     &          .and. targlon < 25.) then
+              ! targlon returned from distbear is just east of the
+              ! GM with a non-360-adjusted value.  Adjust it:
+              targlon = targlon + 360.
+            endif
+            if (xcandlon > 360. .and.
+     &         (targlon >= 0.0 .and. targlon < 180)) then
+              targlon = targlon + 360.
+            endif
+          endif
+
+          call bilin_int_uneven (targlat,targlon
+     &         ,dx,dy,imax,jmax,trkrinfo,1020,'u',xintrp_u
+     &         ,valid_pt,bimct,-99,ibiret1)
+
+          call bilin_int_uneven (targlat,targlon
+     &         ,dx,dy,imax,jmax,trkrinfo,1020,'v',xintrp_v
+     &         ,valid_pt,bimct,-99,ibiret2)
+
+          if (ibiret1 == 0 .and. ibiret2 == 0) then
+
+            call getvrvt (xcandlon,ycandlat,targlon,targlat
+     &                   ,xintrp_u,xintrp_v,vr
+     &                   ,vt,ifh,igvtret)
+
+            if (bear >= 0. .and. bear < 90.) then
+              iq = 1
+            elseif (bear >= 90. .and. bear < 180.) then
+              iq = 2
+            elseif (bear >= 180. .and. bear < 270.) then
+              iq = 3
+            elseif (bear >= 270. .and. bear <= 360.) then
+              iq = 4
+            endif
+
+            vtsum(iq,idist) = vtsum(iq,idist) + vt
+            vtct(iq,idist)  = vtct(iq,idist) + 1
+
+            if ((hemisphere*vt) >= 8.75) then
+              ! If cyclonic Vt exceeds 8.75 m/s (17 kts) at this
+              ! azimuth, then increment the counter for this quad by 1.
+              vt_exceed_17kts_ct(iq,idist) = 
+     &                     vt_exceed_17kts_ct(iq,idist) + 1
+            endif
+
+          endif
+
+        enddo azimloop
+
+        ! If the Vt at 2 out of 4 azimuths exceeds 17 kts (which is 50%
+        ! of 34 kts), then give an automatic pass for that quadrant
+        ! without checking for the mean Vt in this quadrant.
+
+        do nq = 1,numquad
+          if (vt_exceed_17kts_ct(nq,idist) >= 2) then
+            quad_pass_flag(nq) = 'y'
+          endif
+        enddo
+
+        ! Now check again, but this time check for the mean Vt averaged
+        ! over the 4 azimuths in this quadrant.  Yes, it can be
+        ! redundant and set the quad_pass_flag to 'y' again for this
+        ! quadrant, but that's okay.  What it is *not* able to do here
+        ! is take that 'y' setting away that may have just been set in
+        ! the IF statement above with passing 17 kts.
+
+        do nq = 1,numquad
+          ! We need at least 2 valid azimuths in order to get a proper
+          ! mean Vt.
+          if (vtsum(nq,idist) >= 2) then
+            vtavg = vtsum(nq,idist) / vtct(nq,idist)
+            if ((hemisphere*vtavg) >= 7.0) then
+              ! The mean Vt averaged over the 4 azimuths in this
+              ! quadrant at this distance exceeds 7 m/s, which is 13.6
+              ! kts, which is 40% of 34 kts.
+              quad_pass_flag(nq) = 'y'
+            endif
+          endif
+        enddo
+
+      enddo radiusloop
+
+      final_quad_ct = 0
+
+      do nq = 1,numquad
+        if (quad_pass_flag(nq) == 'y') then
+          final_quad_ct = final_quad_ct + 1
+        endif
+      enddo
+
+      if (final_quad_ct == 4) then
+        low_level_wind_circ_flag = 'y'
+      else
+        low_level_wind_circ_flag = 'n'
+      endif
+c
       return
       end
 c

--- a/gettrk_modules.f
+++ b/gettrk_modules.f
@@ -290,6 +290,11 @@ c
                                                ! read in to compute RH
                                                ! if RH is not read in?
                                                ! (y/n)
+        character*1 , save ::   smoothe_mslp_for_gen_scan ! Did 
+                                               ! user request to smoothe
+                                               ! the MSLP data before
+                                               ! scanning for new storms
+                                               ! in the forecast (y/n)?
       end module genesis_diags
 c     
       module tracked_parms
@@ -308,6 +313,7 @@ c
           real, save, allocatable  ::  spfh(:,:,:)
           real, save, allocatable  ::  temperature(:,:,:)
           real, save, allocatable  ::  omega500(:,:)
+          real, save, allocatable  ::  wcirc_grid(:,:,:)
           integer, save, allocatable :: ifhours(:)  
           integer, save, allocatable :: iftotalmins(:)
           integer, save, allocatable :: ifclockmins(:)
@@ -369,6 +375,8 @@ c        real, parameter :: rads_most=300.0, rads_vmag=120.0
 c        real, parameter :: redlm=500.0, ridlm=2000.0
 c        real, parameter :: redlm=500.0, ridlm=1700.0
         real, parameter :: redlm=500.0, ridlm=1000.0
+        real, parameter :: re_genscan=50.0
+        real, parameter :: ri_genscan=100.0
       end module radii
 c
       module grid_bounds
@@ -468,12 +476,12 @@ c
 c
       module waitfor_parms
         character*1 :: use_waitfor ! y or n, for waiting for input files
-        integer :: wait_min_age    ! min age (in seconds)... time since
-                                   ! last file modification
-        integer :: wait_min_size   ! minimum file size in bytes
-        integer :: wait_max_wait   ! max total wait time in seconds 
-        integer :: wait_sleeptime  ! number of seconds to wait between 
-                                   ! checks
+        integer(kind=8) :: wait_min_age    ! min age (in seconds)... time since
+                                           ! last file modification
+        integer(kind=8) :: wait_min_size   ! minimum file size in bytes
+        integer(kind=8) :: wait_max_wait   ! max total wait time in seconds 
+        integer(kind=8) :: wait_sleeptime  ! number of seconds to wait between 
+                                           ! checks
         integer, parameter :: pfc_cmd_len = 800
         character*1 :: use_per_fcst_command ! enable per_fcst_command
         character(pfc_cmd_len) :: per_fcst_command ! command to run every forecast time
@@ -556,7 +564,7 @@ c
           character*30 ::  temp600name ! 600 mb temperature
           character*30 ::  omega500name ! 500 mb omega
         end type netcdfstuff
-        real, save, allocatable    :: netcdf_file_time_values(:)
+        real, save, allocatable :: netcdf_file_time_values(:)
         integer, save, allocatable :: nctotalmins(:)
       end module netcdf_parms
 c---------------------------------------------------------------------c

--- a/module_waitfor.f
+++ b/module_waitfor.f
@@ -3,8 +3,8 @@
         private
         public :: waitfor, run_command
 
-        integer, parameter :: minage_def=30, minsize_def=1
-     &                       ,maxwait_def=-1, sleeptime_def=3
+        integer(kind=8), parameter :: minage_def=30, minsize_def=1
+     &                               ,maxwait_def=-1, sleeptime_def=3
 
       CONTAINS
         subroutine run_command(command,retval)
@@ -14,15 +14,15 @@
 !         Also, this way we get the command return status.
           implicit none
           character(*), intent(in) :: command
-          integer, intent(out) :: retval
+          integer(kind=8), intent(out) :: retval
           call run_cmd_helper(trim(command)//char(0),                   &
      &len_trim(command)+1,retval)
         end subroutine run_command
 
         subroutine run_cmd_helper(cmd,cmdlen,retval)
           implicit none
-          integer, intent(in) :: cmdlen
-          integer, intent(out) :: retval
+          integer(kind=8), intent(in) :: cmdlen
+          integer(kind=8), intent(out) :: retval
           character(*), intent(in) :: cmd(cmdlen)
 
           call c_run_command(retval,cmd)
@@ -32,13 +32,14 @@
      &                    ,sleeptime)
           implicit none
           character(*),intent(in) :: filename
-          integer, optional, intent(in) :: minage
-          integer, optional, intent(in) :: minsize
-          integer, optional, intent(in) :: maxwait
-          integer, optional, intent(in) :: sleeptime
-          integer, intent(out) :: status
+          integer(kind=8), optional, intent(in) :: minage
+          integer(kind=8), optional, intent(in) :: minsize
+          integer(kind=8), optional, intent(in) :: maxwait
+          integer(kind=8), optional, intent(in) :: sleeptime
+          integer(kind=8), intent(out) :: status
 
-          integer :: minage_in, minsize_in, maxwait_in, sleeptime_in
+          integer(kind=8) :: minage_in, minsize_in, maxwait_in
+          integer(kind=8) :: sleeptime_in
 
           status=99
 
@@ -72,17 +73,16 @@
 
         subroutine waitfor_helper(status,minage,minsize
      &        ,maxwait,sleeptime,filename,N)
-          integer, intent(in) :: minage,minsize,maxwait,sleeptime,N
+          integer(kind=8), intent(in) :: minage,minsize,maxwait
+          integer(kind=8), intent(in) :: sleeptime,N
           character(len=N),intent(in) :: filename
-          integer, intent(out) :: status
+          integer(kind=8), intent(out) :: status
 
           character(len=N+1) :: filename0
           character(len=1) :: null
-          integer :: np1
 
           null=char(0)
           filename0=filename//null
-          np1=N+1
 
           call cwaitfor(status,minage,minsize,maxwait,sleeptime
      &                 ,filename0)


### PR DESCRIPTION
There are a number of bugs and updates from my fork included in this PR.

Here are four bugs that are fixed in this update:

  (1) Value of the array index for readgenflag in subroutine
      get_gen_diags was incorrectly set, preventing 850 mb
      moisture divergence from ever being calculated.

  (2) In subroutine first_ges_center, a bunch of counters needed to
      be upgraded from 4-byte to 8-byte integers.  As 4-byte ints,
      they were unable to hold the values that were being summed,
      and as a result the cutoff for the search for new storms at a
      given lead time was being incorrectly set.

  (3) Sam Trahan updated the file-waiting routines that he wrote,
      i.e., cwaitfor.c and module_waitfor.f.  There were a lot of
      variables in these routines that needed to be upgraded from 
      4-byte to 8-byte in order for this waiting procedure to 
      continue working properly for checking on the existence of 
      files with large sizes > 2 GB.

  (4) There was an error in the formatting of the output atcfunix
      record.  An extra comma was included.  I gave a separate fix
      for this one to Zhan Zhang back in June, but I am just getting
      to adding it to GitHub now.

New features include, for TC genesis runs, adding an additional check
for a low-level wind circulation, in order to be more consistent with
how NHC diagnoses genesis for observed storms.  A new subroutine,
check_for_closed_wind_circulation, was added for this purpose.

I added an option that allows the user to request to have the MSLP
data smoothed first before searching for new storms, when run in 
genesis mode.  This was done as a result of a lot of testing I did when
running the tracker in genesis mode on hi-res (3 km) T-SHiELD data.
The MSLP data was particularly noisy, especially for pre-formation 
disturbances in the model, and this was tripping up the various 
algorithms in the tracker that check for things like radial MSLP
gradients and closed MSLP contours.  There is now a flag in the 
namelist which a user can set to specify using this smoothing, and
that smoothing is done in subroutine find_all_maxmins.

I added many tweaks and new checks in subroutine 
check_mslp_radial_gradient, which is a relatively newer routine for
checking in a 360-degree fasion surrounding the storm and also has a       
requirement for scale of a MSLP disturbance.

A major rewrite was done for the I/O for NetCDF files.  Previously,
I had it set for just using 4-byte reals, because the only files I had
ever tested with were GFDL SHiELD NetCDF files, which use 4-byte
reals.  However, this caused problems with 4-byte vs. 8-byte arithmetic
when used with other files, and so I changed all the code surrounding
NetCDF I/O such that it first uses NetCDF library commands to check to
see if the data values are 4-byte or 8-byte and then calls the required
routines accordingly.
