### PR TITLE
Remove u from set -eux command

### DIFF
--- a/src/build_all_cmake.sh
+++ b/src/build_all_cmake.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eux
+set -ex
 source ./machine-setup.sh > /dev/null 2>&1
 
 module use ../modulefiles


### PR DESCRIPTION
On Gaea, if a user has csh as default, having 'u' in the 'set -eux' command broke the build script.  I took out the 'u' from the command.