### PR TITLE
Changes to build tracker on gaea

### DIFF
--- a/modulefiles/modulefile.gaea
+++ b/modulefiles/modulefile.gaea
@@ -6,14 +6,11 @@ proc ModulesHelp { } {
 }
 module-whatis "tracker prerequisites"
 
-module load intel-oneapi/
-module load cray-hdf5
-module load cray-netcdf/4.9.0.3
-
-setenv NetCDF_ROOT /opt/cray/pe/netcdf/4.9.0.3/
-
-module use -a /lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+module use /ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
 module load stack-intel/2023.1.0
+
+module load cray-hdf5
+module load cray-netcdf
 
 module load libpng
 module load jasper

--- a/src/machine-setup.sh
+++ b/src/machine-setup.sh
@@ -100,7 +100,7 @@ elif [[ -d /glade ]] ; then
     fi
     target=yellowstone
     module purge
-elif [[ -d /lustre && -d /ncrc ]] ; then
+elif [[ -d /ncrc ]] ; then
     # We are on GAEA.
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         # We cannot simply load the module command.  The GAEA
@@ -109,7 +109,6 @@ elif [[ -d /lustre && -d /ncrc ]] ; then
         # the module command fails.  Hence we actually have to source
         # /etc/profile here.
         echo load the module command 1>&2
-        source /etc/profile
     fi
     target=gaea
 elif [[ "$(hostname)" =~ "odin" ]]; then


### PR DESCRIPTION
The necessary spack environment was found on the new c5 file system

The changes in this PR contain the needed module loads in order for the cmake build system to run correctly.