### PR TITLE
Add flexibility for MSLP depth in genesis scan

### DIFF
--- a/src/tracker/gettrk_modules.f
+++ b/src/tracker/gettrk_modules.f
@@ -295,6 +295,11 @@ c
                                                ! the MSLP data before
                                                ! scanning for new storms
                                                ! in the forecast (y/n)?
+        real , save :: depth_of_mslp_for_gen_scan ! Depth of the
+                                     ! MSLP field (in mb) that is used
+                                     ! by the initial scan for new
+                                     ! storms in subroutine
+                                     ! check_mslp_radial_gradient
       end module genesis_diags
 c     
       module tracked_parms


### PR DESCRIPTION
Evaluations of genesis over several models (SHiELD, T-SHiELD, GFS and ECMWF) revealed a pronounced low bias in probability of detection statistics. Analysis of select cases from all these models indicated that the threshold of MSLP depth being used as a filter for the initial scan for new storms at each lead time was too stringent.  It was a value of 1 mb in the first 100 km from a candidate model cyclone center.  Interestingly, this value is actually already *weaker* than the best-track-derived value of 1.67 mb / 100 km for observed Atlantic storms from 2019-2023 at the time of observed genesis. So there is some disconnect here, whether it's that the models are too weak, or whether it's that the gradients indicated in the best track are too strong, that remains a topic for further study.  Nonetheless, if we want to capture genesis in the model forecasts, I had to weaken the threshold of MSLP depth used for the initial scan.  I put it at a value of 0.50 mb / 100 km, which is 30% of the observed value described above of 1.67 mb / 100 km.  In terms of the code, I made this MSLP depth value a new namelist variable, depth_of_mslp_for_gen_scan.