### PR TITLE
Change units of istmspd to knots from knots x ten

### DIFF
--- a/src/tracker/gettrk_main.f
+++ b/src/tracker/gettrk_main.f
@@ -4213,7 +4213,8 @@ c           knots (1.9427) is explained in output_atcf.
                   ! using the values from tcvitals for this storm.
 
                   istmdir = storm(ist)%tcv_stdir
-                  istmspd = storm(ist)%tcv_stspd
+                  istmspd = nint((float(storm(ist)%tcv_stspd) / 10.0)
+     &                      * 1.9427)
 
                   write (6,291) storm(ist)%tcv_storm_id
      &                         ,storm(ist)%tcv_storm_name
@@ -14864,7 +14865,7 @@ c     is requested.
       stmspd  = distm / dt
 
       stmspdkts = stmspd * conv_ms_knots
-      istmspd = int ((stmspdkts * 10) + 0.5)
+      istmspd = nint (stmspdkts)
 
       xincr = slonfg(ist,ifh+1) - fixlon(ist,ifh)
       yincr = slatfg(ist,ifh+1) - fixlat(ist,ifh)


### PR DESCRIPTION
In the ouptut atcfunix record, the tracker-diagnosed translation speed of the model storm motion is output.  Since the day I first switched from the old ATCF format to the new atcfunix format in 1999, I've been using a value for the units of translation speed as knots*10.  This was following the guidance from NHC on the format at the time.  At some point since then, the format has changed so that the units are now just knots.  I had to modify the code in two locations to make this compliant.  The value is stored in the istmspd variable before being written out.