### PR TITLE
Update modulefile.wcoss2 to remove unnecessary stuff

### DIFF
--- a/modulefiles/modulefile.wcoss2
+++ b/modulefiles/modulefile.wcoss2
@@ -6,13 +6,10 @@ module purge
 module load envvar/1.0
 module load PrgEnv-intel/8.1.0
 module load craype/2.7.10
-module load intel/19.1.3.304
-module load cray-mpich/8.1.9
+module load intel-classic/2022.2.0.262
 module load cray-pals/1.0.12
 
 module load libpng/1.6.37
-module load libjpeg/9c                                                                               
-setenv JPEG_LIBRARIES /apps/spack/libjpeg/9c/intel/19.1.3.304/jkr3isi257ktoouprwaxcn4twtye747z/lib
 module load zlib/1.2.11
 module load jasper/2.0.25
 
@@ -23,8 +20,3 @@ module load g2/3.4.5
 module load w3emc/2.9.1
 module load w3nco/2.4.1
 module load bacio/2.4.1
-
-setenv CMAKE_C_COMPILER cc
-setenv CMAKE_CXX_COMPILER CC
-setenv CMAKE_Fortran_COMPILER ftn
-setenv CMAKE_Platform wcoss2


### PR DESCRIPTION
Updated modulefile.wcoss2 to use latest intel compiler and also to remove craympich and libjpeg.