### PR TITLE
adds 64bit wrapper around var1 variable

### DIFF
--- a/code/src/tracker/gettrk_subroutines.f
+++ b/code/src/tracker/gettrk_subroutines.f
@@ -25344,7 +25344,7 @@ c     tracker was compiled in.
         enddo
       elseif (xtype == 6) then
         ! Read data into an 8-byte double real array
-        status = nf_get_var_double (ncid,var1id,var1)
+        status = nf_get_var_double (ncid,var1id,real(var1,kind=8))
         if (status .ne. NF_NOERR) call handle_netcdf_err(status)
         do i = 1,nmax
           var1(i) = readvar8(i)


### PR DESCRIPTION
While compiling with gcc, the compiler flagged this as an error in the subroutine `get_var1_one_dim`.

The error is as follows:
```
25347 |         status = nf_get_var_double (ncid,var1id,var1)
            |                                                                                1
......
25420 |       status = nf_get_var_double (ncid,var1id,readvar8)
            |                                                                                 2  
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(4)/REAL(8)).
```

To fix this, I added a real kind=8 wrapper around the var1 argument.

I tested this fix by:
 compiling and running on analysis using intel-oneapi-compilers with netcdf data, all numbers reproduced
 compiling and running on jet using intel-oneapi-compilers with grip data, some atcf files had differences

