### PR TITLE
Fixes multiple gcc compilation errors

### DIFF
--- a/code/src/tracker/gettrk_subroutines.f
+++ b/code/src/tracker/gettrk_subroutines.f
@@ -14516,6 +14516,7 @@ c
       real      ucomp,vcomp,xdist,ydist,ydeg,dt,extraplat
       real      cosfac
       real      dtkm
+      character(len=1) :: in_grid, extrap_flag
 c
       in_grid = 'n'
       extrap_flag = 'y'

--- a/code/src/tracker/gettrk_subroutines.f
+++ b/code/src/tracker/gettrk_subroutines.f
@@ -4247,9 +4247,9 @@ c
         print *,'gopen_g_file= ',gopen_g_file
         print *,'gopen_i_file= ',gopen_i_file
 
-        write (6,81) gopen_g_file,gopen_i_file
-   81   format (1x,'tpm gopen_g_file= ...',a<nlen1>
-     &         ,'...  gopen_i_file= ...',a<nlen2>,'...')
+c        write (6,81) gopen_g_file,gopen_i_file
+c   81   format (1x,'tpm gopen_g_file= ...',a<nlen1>
+c     &         ,'...  gopen_i_file= ...',a<nlen2>,'...')
 
         print *,'gopen_g_file= ',gopen_g_file,'....'
         print *,'gopen_i_file= ',gopen_i_file,'....'


### PR DESCRIPTION
There are a few errors that break compiling the executables with gcc.
This PR suggests fixes for those errors.

They include:

Adding a 64bit real wrapper around the var1 argument in the call to function `nf_get_var_double` in subroutine `get_var1_one_dim` 
The error was as follows:
```
25347 |         status = nf_get_var_double (ncid,var1id,var1)
      |                                                   1
......
25420 |       status = nf_get_var_double (ncid,var1id,readvar8)
      |                                                     2  
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(4)/REAL(8)).
```

A formatting error. I have not been able to find a work around for this print statement and also I have not seen it printed in any of the output I have been testing with. For now, I have just commented these lines out.
The error is as follows:
```
 4251 |    81   format (1x,'tpm gopen_g_file= ...',a<nlen1>
      |                                             1
Error: Unexpected element '<' in format string at (1)
```

The last one is a conversion error for 2 variables, `in_grid` and `extra_flag` in subroutine `advect_tcvitals_from_hour0' . To fix this I just added a character data declaration for these variables.
The errors were as follows:
```
14520 |       in_grid = 'n'
      |                1
Error: Cannot convert CHARACTER(1) to INTEGER(4) at (1)

14521 |       extrap_flag = 'y'
      |                    1
Error: Cannot convert CHARACTER(1) to REAL(4) at (1)
```

I tested these fixes by:
compiling and running on analysis using intel-oneapi-compilers with netcdf data, all numbers & atcf track files reproduced 
compiling and running on jet using intel-oneapi-compilers with grip data, some atcf files had differences
