### PR TITLE
Fixes cmake build errors on Gaea

### DIFF
--- a/code/modulefile-setup/gaea-setup.sh
+++ b/code/modulefile-setup/gaea-setup.sh
@@ -1,7 +1,7 @@
 # set up module environment on gaea
 
 module use /ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
-module load stack-intel/2023.1.0
+module load stack-intel/2023.2.0
 
 module load cray-hdf5
 module load cray-netcdf
@@ -19,7 +19,6 @@ module load nco
 module load cdo
 
 export ncdump=/opt/cray/pe/netcdf/4.9.0.3/bin/ncdump
-export LD_PRELOAD=/opt/cray/pe/gcc/12.2.0/snos/lib64/libstdc++.so.6
 
 # for grib data
 module load grib-util


### PR DESCRIPTION
The spack environment spack-stack-1.6.0 on gaea no longer has intel version 2023.1.0 
Currently, that is what the gaea-setup.sh is trying to load.

This PR loads the correct intel version which is intel/2023.2.0 in the gaea-setup.sh script. It also removes the LD_preload environment variable as it is no longer need with this intel version.