### PR TITLE
Removes deprecated w3nco library & fixes gaea build

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(Jasper REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(g2 REQUIRED)
 find_package(bacio REQUIRED)
-find_package(w3nco REQUIRED)
 find_package(w3emc REQUIRED)
 
 enable_testing()

--- a/code/modulefile-setup/gaea-setup.sh
+++ b/code/modulefile-setup/gaea-setup.sh
@@ -1,7 +1,7 @@
 # set up module environment on gaea
 
 module use /ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
-module load stack-intel/2023.1.0
+module load stack-intel/2023.2.0
 
 module load cray-hdf5
 module load cray-netcdf
@@ -19,7 +19,6 @@ module load nco
 module load cdo
 
 export ncdump=/opt/cray/pe/netcdf/4.9.0.3/bin/ncdump
-export LD_PRELOAD=/opt/cray/pe/gcc/12.2.0/snos/lib64/libstdc++.so.6
 
 # for grib data
 module load grib-util

--- a/code/modulefile-setup/hera-setup.sh
+++ b/code/modulefile-setup/hera-setup.sh
@@ -15,7 +15,6 @@ module load libpng
 module load g2
 module load g2tmpl
 module load w3emc
-module load w3nco
 
 module load nco
 module load cdo

--- a/code/modulefile-setup/hercules-setup.sh
+++ b/code/modulefile-setup/hercules-setup.sh
@@ -16,4 +16,3 @@ module load g2
 module load g2tmpl
 module load bacio
 module load w3emc
-module load w3nco

--- a/code/modulefile-setup/jet-setup.sh
+++ b/code/modulefile-setup/jet-setup.sh
@@ -17,7 +17,6 @@ module load g2
 module load g2tmpl
 module load bacio
 module load w3emc
-module load w3nco
 
 module load nco
 module load cdo

--- a/code/modulefile-setup/orion-setup.sh
+++ b/code/modulefile-setup/orion-setup.sh
@@ -17,7 +17,6 @@ module load g2
 module load g2tmpl
 module load bacio
 module load w3emc
-module load w3nco
 
 module load nco
 module load cdo

--- a/code/modulefile-setup/ppan-setup.sh
+++ b/code/modulefile-setup/ppan-setup.sh
@@ -15,7 +15,6 @@ module load g2
 module load g2tmpl
 module load bacio
 module load w3emc
-module load w3nco
 
 module load nco
 module load cdo

--- a/code/src/support/CMakeLists.txt
+++ b/code/src/support/CMakeLists.txt
@@ -20,8 +20,7 @@ target_link_libraries(
   supvit.x
   g2::g2_d
   bacio::bacio_4
-  w3emc::w3emc_d
-  w3nco::w3nco_d)
+  w3emc::w3emc_d)
 
 install(TARGETS supvit.x DESTINATION ${CMAKE_SOURCE_DIR}/exec)
 
@@ -36,8 +35,7 @@ target_link_libraries(
   tave.x
   g2::g2_d
   bacio::bacio_4
-  w3emc::w3emc_d
-  w3nco::w3nco_d)
+  w3emc::w3emc_d)
 
 install(TARGETS tave.x DESTINATION ${CMAKE_SOURCE_DIR}/exec)
 
@@ -52,7 +50,6 @@ target_link_libraries(
   vint.x
   g2::g2_d
   bacio::bacio_4
-  w3emc::w3emc_d
-  w3nco::w3nco_d)
+  w3emc::w3emc_d)
 
 install(TARGETS vint.x DESTINATION ${CMAKE_SOURCE_DIR}/exec)

--- a/code/src/tracker/CMakeLists.txt
+++ b/code/src/tracker/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(
   g2::g2_d
   bacio::bacio_4
   w3emc::w3emc_d
-  w3nco::w3nco_d
   NetCDF::NetCDF_Fortran
   ${JASPER_LIBRARIES}
   ${PNG_LIBRARIES})
@@ -40,7 +39,6 @@ target_link_libraries(
   g2::g2_d
   bacio::bacio_4
   w3emc::w3emc_d
-  w3nco::w3nco_d
   NetCDF::NetCDF_Fortran
   ${JASPER_LIBRARIES}
   ${PNG_LIBRARIES})


### PR DESCRIPTION
Any versions of w3emc 2.8.0 and above have now migrated the library w3nco into it.
This PR suggests the removal of any use of the library w3nco as all rdhpc systems use a current version of w3emc, so w3nco is no longer needed
These changes were tested by building & compiling on every rdhpcs system, ran the tracker on analysis with netcdf data, and also ran the tracker with grib data on jet but had some differing files

The spack environment spack-stack-1.6.0 on gaea no longer has intel version 2023.1.0
Currently, that is what the gaea-setup.sh is trying to load.
This PR also changes the correct intel version which is intel/2023.2.0 in the gaea-setup.sh script. It also removes the LD_preload environment variable as it is no longer need with this intel version.
These changes were testing by building, compiling, and running the tracker with netcdf data.

