### PR TITLE
Adds updated setup scripts for wcoss2 machine

### DIFF
--- a/code/modulefile-setup/wcoss2-setup.sh
+++ b/code/modulefile-setup/wcoss2-setup.sh
@@ -1,21 +1,28 @@
-# set up module environment on wcoss2
+# set up module environment for wcoss2
 
-# System and compiler prereqs:
-module purge
 module load envvar/1.0
-module load PrgEnv-intel/8.1.0
-module load craype/2.7.10
-module load intel-classic/2022.2.0.262
-module load cray-pals/1.0.12
+module load PrgEnv-intel/8.3.3
+module load intel-oneapi/2022.2.0.262
 
-module load libpng/1.6.37
-module load zlib/1.2.11
-module load jasper/2.0.25
+module load cmake/3.20.2
 
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-
-module load g2/3.4.5
-module load w3emc/2.9.1
-module load w3nco/2.4.1
+module load jasper/2.0.25
+module load zlib/1.2.11
+module load libpng/1.6.37
+module load g2/3.5.1
+module load g2tmpl/1.13.0
 module load bacio/2.4.1
+module load w3emc/2.12.0
+
+module load nco/4.7.9
+module load cdo/1.9.8
+
+export ncdump=/apps/prod/hpc-stack/intel-19.1.3.304/netcdf/4.7.4/bin/ncdump
+
+
+# for grib data
+module load libjpeg/9c
+module load grib_util/1.2.2
+module load wgrib2/2.0.8_wmo 

--- a/code/src/machine-setup.sh
+++ b/code/src/machine-setup.sh
@@ -25,7 +25,9 @@ orion=("orion-login-1.hpc.msstate.edu" "orion-login-2.hpc.msstate.edu" \
 hercules=("hercules-login-1.hpc.msstate.edu" "hercules-login-2.hpc.msstate.edu" \
           "hercules-login-3.hpc.msstate.edu" "hercules-login-4.hpc.msstate.edu")
 
-#wcoss2= this will have to be done when I have access to wcoss2
+# wcoss2 will be saved under the same target name regardless if on dogwood or cactus
+wcoss2=("dlogin01" "dlogin02" "dlogin03" "dlogin04" "dlogin05" "dlogin06" "dlogin07" "dlogin08" "dlogin09" \
+        "clogin01" "clogin02" "clogin03" "clogin04" "clogin05" "clogin06" "clogin07" "clogin08" "clogin09")
 
 # loop through each system array for a matching login-node to set target = to the correct machine
 for i in "${!analysis[@]}"; do
@@ -75,3 +77,12 @@ for i in "${!hercules[@]}"; do
     echo $target
   fi
 done
+
+for i in "${!wcoss2[@]}"; do
+  if [ "${wcoss2[$i]}" == $HOSTNAME ]; then
+    source $MODULESHOME/init/bash
+    target=wcoss2
+    echo $target
+  fi
+done
+


### PR DESCRIPTION
This PR supports:

Updating all modules in the wcoss2-setup.sh
Removing any modules that were unnecessary
Keeping module versions explicit. Other setup scripts do not have explicit versions, however I feel like being explicit with versions can be beneficial on this machine.

Adding a wcoss2 array in the machine-setup.sh that is populated with all the available hostnames/login nodes for both dogwood and cactus systems. The target will still be set as wcoss2 regardless of which system user is on, i.e. dogwood or cactus.
Also adds the loop that goes through the hostname machine array, and sets wcoss2 as target variable.

This was tested by building and compiling on both dogwood and cactus systems.
 