### PR TITLE
Fortran flag updates to cmake system

### DIFF
--- a/code/modulefile-setup/gaea-setup.sh
+++ b/code/modulefile-setup/gaea-setup.sh
@@ -1,6 +1,6 @@
 # set up module environment on gaea
 
-module use /ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+module use /ncrc/proj/epic/spack-stack/spack-stack-1.7.0/envs/ue-intel/install/modulefiles/Core
 module load stack-intel/2023.2.0
 
 module load cray-hdf5
@@ -8,7 +8,7 @@ module load cray-netcdf
 
 module load libpng
 module load jasper
-module load zlib
+module load zlib-ng
 module load g2
 module load g2tmpl
 module load bacio
@@ -17,7 +17,7 @@ module load w3emc
 module load nco
 module load cdo
 
-export ncdump=/opt/cray/pe/netcdf/4.9.0.3/bin/ncdump
+export ncdump=/opt/cray/pe/netcdf/4.9.0.13/bin/ncdump
 
 # for grib data
 module load grib-util

--- a/code/src/debug-cmake.sh
+++ b/code/src/debug-cmake.sh
@@ -17,7 +17,11 @@ mkdir build
 cd build
 
 # build src code
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILER=icx
+if [ $target = gaea ]; then
+  cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_COMPILER=ftn -DCMAKE_C_COMPILER=cc
+else
+  cmake .. -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILER=icx
+fi
 
 # compile
 make VERBOSE=1

--- a/code/src/debug-cmake.sh
+++ b/code/src/debug-cmake.sh
@@ -20,7 +20,7 @@ cd build
 if [ $target = gaea ]; then
   cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_COMPILER=ftn -DCMAKE_C_COMPILER=cc
 else
-  cmake .. -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILER=icx
+  cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILER=icx
 fi
 
 # compile

--- a/code/src/debug-cmake.sh
+++ b/code/src/debug-cmake.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# adds $target variable to identify which rdhpc system you're on
+source machine-setup.sh
+
+# loads any module/packages needed for cmake build
+cd ../modulefile-setup
+source $target-setup.sh
+module list
+
+# makes and enters build directory
+cd ..
+if [ -d "build" ]; then
+   rm -rf build
+fi
+mkdir build
+cd build
+
+# build src code
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILER=icx
+
+# compile
+make VERBOSE=1
+
+echo " COMPLETE "
+
+# back out of build directory
+cd ..
+exit

--- a/code/src/debug-cmake.sh
+++ b/code/src/debug-cmake.sh
@@ -22,7 +22,11 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_COMPILER=ifx -DCMAKE_C_COMPILE
 # compile
 make VERBOSE=1
 
-echo " COMPLETE "
+if [ $? -eq 0 ]; then
+  echo "COMPILATION SUCCESSFUL"
+else
+  echo "COMPILATION ERROR"
+fi
 
 # back out of build directory
 cd ..

--- a/code/src/run-cmake.sh
+++ b/code/src/run-cmake.sh
@@ -26,11 +26,15 @@ fi
 # compile
 make
 
+if [ $? -eq 0 ]; then
+  echo "COMPILATION SUCCESSFUL"
+else
+  echo "COMPILATION ERROR"
+fi
+
 # install executables in exec/ directory
 make install
 
 # back out of build directory
 cd ..
 exit
-
-

--- a/code/src/support/CMakeLists.txt
+++ b/code/src/support/CMakeLists.txt
@@ -13,6 +13,9 @@ elseif (Fortran_COMPILER_NAME MATCHES "ifx.*")
   set (CMAKE_Fortran_FLAGS "-fp-model=precise -i4 -r8")     # ifx fortran compiler flags here
 endif()
 
+# debug mode
+set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -<flags>")
+
 # set up build for supvit support code
 set(supvit_srcs
   supvit/supvit_main.f

--- a/code/src/support/CMakeLists.txt
+++ b/code/src/support/CMakeLists.txt
@@ -5,9 +5,12 @@
 #        timothy.marchok@noaa.gov
 #----------------------------------------------------------
 
-# add if statement in case user is using gcc
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O2 -fp-model precise -i4 -r8")
+# set fortran compiler flags
+get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
+if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
+  set (CMAKE_Fortran_FLAGS "-Wall -Wextra")     # gcc fortran compiler flags here
+elseif (Fortran_COMPILER_NAME MATCHES "ifx.*")
+  set (CMAKE_Fortran_FLAGS "-fp-model=precise -i4 -r8")     # ifx fortran compiler flags here
 endif()
 
 # set up build for supvit support code

--- a/code/src/support/CMakeLists.txt
+++ b/code/src/support/CMakeLists.txt
@@ -8,13 +8,13 @@
 # set fortran compiler flags
 get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
-  set (CMAKE_Fortran_FLAGS "-Wall -Wextra")     # gcc fortran compiler flags here
+  set (CMAKE_Fortran_FLAGS "-Wall -Wextra")                 # gcc fortran compiler flags here
 elseif (Fortran_COMPILER_NAME MATCHES "ifx.*")
   set (CMAKE_Fortran_FLAGS "-fp-model=precise -i4 -r8")     # ifx fortran compiler flags here
 endif()
 
 # debug mode
-set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -<flags>")
+set (CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0")
 
 # set up build for supvit support code
 set(supvit_srcs

--- a/code/src/tracker/CMakeLists.txt
+++ b/code/src/tracker/CMakeLists.txt
@@ -17,13 +17,13 @@ add_executable(gettrk.x gettrk_main.f ${tracker_src})
 # set fortran compiler flags
 get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
-  set (CMAKE_Fortran_FLAGS "-Wall -Wextra")     # gcc fortran compiler flags here
+  set (CMAKE_Fortran_FLAGS "-Wall -Wextra")                 # gcc fortran compiler flags here
 elseif (Fortran_COMPILER_NAME MATCHES "ifx.*")
   set (CMAKE_Fortran_FLAGS "-fp-model=precise -i4 -r8")     # ifx fortran compiler flags here
 endif()
 
 # debug mode
-set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0")
+set (CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0")
 
 target_link_libraries(
   gettrk.x

--- a/code/src/tracker/CMakeLists.txt
+++ b/code/src/tracker/CMakeLists.txt
@@ -22,6 +22,9 @@ elseif (Fortran_COMPILER_NAME MATCHES "ifx.*")
   set (CMAKE_Fortran_FLAGS "-fp-model=precise -i4 -r8")     # ifx fortran compiler flags here
 endif()
 
+# debug mode
+set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0")
+
 target_link_libraries(
   gettrk.x
   g2::g2_d

--- a/code/src/tracker/CMakeLists.txt
+++ b/code/src/tracker/CMakeLists.txt
@@ -14,9 +14,12 @@ set(tracker_src
 
 add_executable(gettrk.x gettrk_main.f ${tracker_src})
 
-# add if statement in case user is using gcc
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O2 -fp-model precise -i4 -r8")
+# set fortran compiler flags
+get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
+if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
+  set (CMAKE_Fortran_FLAGS "-Wall -Wextra")     # gcc fortran compiler flags here
+elseif (Fortran_COMPILER_NAME MATCHES "ifx.*")
+  set (CMAKE_Fortran_FLAGS "-fp-model=precise -i4 -r8")     # ifx fortran compiler flags here
 endif()
 
 target_link_libraries(


### PR DESCRIPTION
This PR suggests multiple changes to the vortex tracker cmake build system.
These suggestions include:

-Changing the way the fortran compiler flags are set in both the tracker/CMakeLists.txt file and the support/CMakeLists.txt files

Currently, there is an if-statement in these files that set fortran flags if the user is compiling with intel-oneapi. This if-statement is needed in case a user wants to compiler with other compilers such as gcc. In that case, the cmake code is able to bypass the intel-oneapi flags which would break during a compilation with gcc.
The following changes to the CMakeLists.txt files are necessary due to the newer installations of the intel-oneapi compilers ifx and icx. With these new compilers came changes in how the flags need to be set and how they operate. The current way in which the flags are set are no longer operating as they are expected. When the user runs the run-cmake.sh script, the fortran flags are not set due to the syntax in which they are coded.
These edits fix the above mentioned issues and will ensure consistency during the compilation of the tracker's source code.
The tracker source code will now default to compile with the flags `-fp-model=precise -i4 -r8`
These are the recommended flags, however the user is easily able to change these according to what their desired result.
*Side note: the `-O2` optimization flag is omitted from the flag list because this is a defaulted optimization when compiling with ifx

-Adds a debugging mode

Instead of the user needing to go into the both CMakeLists.txt files (tracker/ and support/) and edit the defaulted fortran flags, there is now a newly added debug-cmake.sh script.
The only debugging flag that are specifically added to this debug mode is the `O0` optimization flag because the cmake system automatically compiles with `-g`
A very commonly used debugging flag `-check` is currently breaking code. This issue is still being researched. Once a resolution is known as to why the `-check` flag breaks the compilation it will be added into the defaulted debugging flags.
Once again, additional debugging flags can be included into the debug mode sections of the CMakeLists.txt files at the users discretion.
 
-Other smaller changes included in this PR
Updating the gaea-setup.sh with newer spack environment 
Adding a success/failure message after compilation for both regular and debug modes


These changes were tested by:
-running both the run-cmake.sh and debug-cmake.sh scripts on analysis successfully including running the tracker with multiple hurricane cases including t-SHiELD and SHiELD
-running both the run-cmake.sh and debug-cmake.sh scripts on Gaea, Jet, and Hera

These changes were **not** tested:
-on rdhpc systems Orion, Hera, or WCOSS2
-tested with running any hurricane cases using GRIB1 or GRIB2 data
These items will be tested in the near future and the vortex tracker repository will be modified/updated if necessary  